### PR TITLE
Complete phase 2 masking and binning enhancements

### DIFF
--- a/docs/issues/phase2-masking-binning.md
+++ b/docs/issues/phase2-masking-binning.md
@@ -1,0 +1,18 @@
+---
+title: "Phase 2: Masking, apodization, and binning"
+tags:
+  - phase-2
+  - masking
+  - binning
+status: done
+---
+
+## Tasks
+- Extend `commutator_common.build_mask` to support configurable thresholds and C1 apodization.
+- Provide a `scripts/make_mask.py` CLI that writes the combined mask and metadata artefacts.
+- Wire preregistration binning into the commutator helpers with regression tests covering the expected bin count.
+
+## Outcome
+- Masks derived from Planck maps now apply RMS thresholding followed by configurable apodization, with sky fraction summaries.
+- The new CLI produces reproducible mask artefacts and reports metadata including the resulting `f_sky`.
+- Bin definitions follow the preregistration YAML, and tests assert both the mask sky fraction window and bin multiplicity.

--- a/roadmap_checklist.md
+++ b/roadmap_checklist.md
@@ -14,9 +14,9 @@
 - [x] Tests for FITS header parsing and unit sanity checks
 
 ### Phase 2 — Masking, Apodization, and Binning
-- [ ] Extend `commutator_common.build_mask`  
-- [ ] Create `scripts/make_mask.py`  
-- [ ] Tests: f_sky within [0.5, 0.9], bin count matches config  
+- [x] Extend `commutator_common.build_mask`
+- [x] Create `scripts/make_mask.py`
+- [x] Tests: f_sky within [0.5, 0.9], bin count matches config
 
 ### Phase 3 — Spectra Deconvolution & Windows
 - [ ] Implement `namaster_utils.py` helpers  

--- a/scripts/make_mask.py
+++ b/scripts/make_mask.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import healpy as hp
+import numpy as np
+from commutator_common import build_mask, effective_f_sky, read_map, save_json, summary_line
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a combined mask with apodization")
+    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--cmb", default="COM_CompMap_CMB-smica_2048_R1.20.fits")
+    parser.add_argument("--phi", default="COM_CompMap_Lensing_2048_R1.10.fits")
+    parser.add_argument(
+        "--quick-nside", type=int, default=256, help="Optional downgrade before masking"
+    )
+    parser.add_argument("--threshold-sigma", type=float, default=5.0)
+    parser.add_argument("--apod-arcmin", type=float, default=30.0)
+    parser.add_argument("--out", type=Path, default=Path("artifacts/mask.npy"))
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir)
+    cmb = read_map(data_dir / args.cmb, quick_nside=args.quick_nside)
+    phi = read_map(data_dir / args.phi, quick_nside=args.quick_nside)
+
+    mask_cmb = build_mask(cmb, threshold_sigma=args.threshold_sigma, apod_arcmin=args.apod_arcmin)
+    mask_phi = build_mask(phi, threshold_sigma=args.threshold_sigma, apod_arcmin=args.apod_arcmin)
+    mask = np.clip(mask_cmb * mask_phi, 0.0, 1.0)
+
+    out_path = args.out
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    np.save(out_path, mask)
+
+    metadata = {
+        "cmb": args.cmb,
+        "phi": args.phi,
+        "quick_nside": int(hp.get_nside(cmb)),
+        "threshold_sigma": float(args.threshold_sigma),
+        "apod_arcmin": float(args.apod_arcmin),
+        "f_sky": effective_f_sky(mask),
+        "path": out_path.as_posix(),
+    }
+    save_json(metadata, out_path.with_suffix(".json"))
+    summary_line(
+        "built mask {path} with f_sky={f_sky:.3f}".format(
+            path=out_path.as_posix(), f_sky=metadata["f_sky"]
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_order_A_to_B.py
+++ b/scripts/run_order_A_to_B.py
@@ -8,6 +8,7 @@ import healpy as hp
 import numpy as np
 from commutator_common import (
     build_mask,
+    load_bins_from_prereg,
     nm_bandpowers,
     nm_bins_from_params,
     nm_field_from_scalar,
@@ -24,7 +25,16 @@ def main():
     ap.add_argument("--phi", default="COM_CompMap_Lensing_2048_R1.10.fits")
     ap.add_argument("--quick-nside", type=int, default=256, help="Downsample before analysis")
     ap.add_argument("--nlb", type=int, default=50)
-    ap.add_argument("--lmax", type=int, default=None)  # kept for interface parity, not used
+    ap.add_argument("--lmax", type=int, default=None)
+    ap.add_argument("--lmin", type=int, default=None)
+    ap.add_argument("--threshold-sigma", type=float, default=5.0)
+    ap.add_argument("--apod-arcmin", type=float, default=30.0)
+    ap.add_argument(
+        "--prereg",
+        type=Path,
+        default=Path("config/prereg.yaml"),
+        help="Path to prereg YAML for bin configuration",
+    )
     ap.add_argument("--out", default="artifacts/order_A_to_B.npz")
     args = ap.parse_args()
 
@@ -33,8 +43,36 @@ def main():
     phi = read_map(d / args.phi, quick_nside=args.quick_nside)
     nside = hp.get_nside(cmb)
 
-    mask = (build_mask(cmb) * build_mask(phi)).astype(float)
-    bins = nm_bins_from_params(nside=nside, lmax=args.lmax, nlb=args.nlb)
+    mask = (
+        build_mask(
+            cmb,
+            threshold_sigma=args.threshold_sigma,
+            apod_arcmin=args.apod_arcmin,
+        )
+        * build_mask(
+            phi,
+            threshold_sigma=args.threshold_sigma,
+            apod_arcmin=args.apod_arcmin,
+        )
+    ).astype(float)
+    mask = np.clip(mask, 0.0, 1.0)
+
+    bins = None
+    bins_meta = None
+    try:
+        bins, bins_meta = load_bins_from_prereg(args.prereg, nside=nside)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:  # pragma: no cover - keep fallback path available
+        summary_line(f"failed to load prereg bins: {exc}; falling back to CLI params")
+
+    if bins is None:
+        bins = nm_bins_from_params(
+            nside=nside,
+            lmax=args.lmax,
+            lmin=args.lmin,
+            nlb=args.nlb,
+        )
 
     f1 = nm_field_from_scalar(cmb, mask)
     f2 = nm_field_from_scalar(phi, mask)
@@ -42,7 +80,15 @@ def main():
 
     np.savez(Path(args.out), cl=cl, nside=nside, nlb=args.nlb)
     save_json(
-        {"order": "A_to_B", "nside": nside, "nbins": int(cl.size)},
+        {
+            "order": "A_to_B",
+            "nside": nside,
+            "nbins": int(cl.size),
+            "mask_threshold_sigma": args.threshold_sigma,
+            "mask_apod_arcmin": args.apod_arcmin,
+            "bins_source": "prereg" if bins_meta is not None else "cli",
+            "bins": bins_meta,
+        },
         Path(args.out).with_suffix(".json"),
     )
     summary_line(f"wrote {args.out} with {cl.size} bins at nside={nside}")

--- a/scripts/run_order_B_to_A.py
+++ b/scripts/run_order_B_to_A.py
@@ -8,6 +8,7 @@ import healpy as hp
 import numpy as np
 from commutator_common import (
     build_mask,
+    load_bins_from_prereg,
     nm_bandpowers,
     nm_bins_from_params,
     nm_field_from_scalar,
@@ -24,7 +25,16 @@ def main():
     ap.add_argument("--phi", default="COM_CompMap_Lensing_2048_R1.10.fits")
     ap.add_argument("--quick-nside", type=int, default=256, help="Downsample before analysis")
     ap.add_argument("--nlb", type=int, default=50)
-    ap.add_argument("--lmax", type=int, default=None)  # kept for interface parity, not used
+    ap.add_argument("--lmax", type=int, default=None)
+    ap.add_argument("--lmin", type=int, default=None)
+    ap.add_argument("--threshold-sigma", type=float, default=5.0)
+    ap.add_argument("--apod-arcmin", type=float, default=30.0)
+    ap.add_argument(
+        "--prereg",
+        type=Path,
+        default=Path("config/prereg.yaml"),
+        help="Path to prereg YAML for bin configuration",
+    )
     ap.add_argument("--out", default="artifacts/order_B_to_A.npz")
     args = ap.parse_args()
 
@@ -33,8 +43,36 @@ def main():
     phi = read_map(d / args.phi, quick_nside=args.quick_nside)
     nside = hp.get_nside(cmb)
 
-    mask = (build_mask(cmb) * build_mask(phi)).astype(float)
-    bins = nm_bins_from_params(nside=nside, lmax=args.lmax, nlb=args.nlb)
+    mask = (
+        build_mask(
+            cmb,
+            threshold_sigma=args.threshold_sigma,
+            apod_arcmin=args.apod_arcmin,
+        )
+        * build_mask(
+            phi,
+            threshold_sigma=args.threshold_sigma,
+            apod_arcmin=args.apod_arcmin,
+        )
+    ).astype(float)
+    mask = np.clip(mask, 0.0, 1.0)
+
+    bins = None
+    bins_meta = None
+    try:
+        bins, bins_meta = load_bins_from_prereg(args.prereg, nside=nside)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:  # pragma: no cover
+        summary_line(f"failed to load prereg bins: {exc}; falling back to CLI params")
+
+    if bins is None:
+        bins = nm_bins_from_params(
+            nside=nside,
+            lmax=args.lmax,
+            lmin=args.lmin,
+            nlb=args.nlb,
+        )
 
     f1 = nm_field_from_scalar(phi, mask)
     f2 = nm_field_from_scalar(cmb, mask)
@@ -42,7 +80,15 @@ def main():
 
     np.savez(Path(args.out), cl=cl, nside=nside, nlb=args.nlb)
     save_json(
-        {"order": "B_to_A", "nside": nside, "nbins": int(cl.size)},
+        {
+            "order": "B_to_A",
+            "nside": nside,
+            "nbins": int(cl.size),
+            "mask_threshold_sigma": args.threshold_sigma,
+            "mask_apod_arcmin": args.apod_arcmin,
+            "bins_source": "prereg" if bins_meta is not None else "cli",
+            "bins": bins_meta,
+        },
         Path(args.out).with_suffix(".json"),
     )
     summary_line(f"wrote {args.out} with {cl.size} bins at nside={nside}")

--- a/src/comet/masking.py
+++ b/src/comet/masking.py
@@ -1,0 +1,84 @@
+"""Mask construction and apodization utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency in CI
+    import pymaster as nmt
+except Exception as exc:  # pragma: no cover
+    raise RuntimeError(
+        "pymaster (NaMaster) is required for mask apodization. "
+        "Install it from conda-forge as 'namaster'."
+    ) from exc
+
+
+def _as_float_array(mask: np.ndarray) -> np.ndarray:
+    arr = np.asarray(mask, dtype=float)
+    if arr.ndim != 1:
+        raise ValueError(f"Mask must be 1-D, got shape {arr.shape}")
+    return arr
+
+
+def threshold_mask(m: np.ndarray, threshold_sigma: float = 10.0) -> np.ndarray:
+    """Return a binary mask after applying an RMS-based threshold."""
+
+    if threshold_sigma <= 0:
+        raise ValueError("threshold_sigma must be positive")
+
+    x = np.asarray(m, dtype=float)
+    if x.ndim != 1:
+        raise ValueError(f"Input map must be 1-D, got shape {x.shape}")
+
+    finite = np.isfinite(x)
+    if not finite.any():
+        raise ValueError("Input map has no finite pixels to mask")
+
+    cleaned = np.where(finite, x, 0.0)
+    rms = float(np.sqrt(np.mean(cleaned**2)))
+    if not np.isfinite(rms) or rms == 0:
+        rms = 1.0
+
+    mask = finite & (np.abs(cleaned) < threshold_sigma * (rms + 1e-30))
+    return mask.astype(float)
+
+
+def apodize_mask(mask: np.ndarray, apod_arcmin: float | None = None) -> np.ndarray:
+    """Apply NaMaster C1 apodization with the requested radius (in arcminutes)."""
+
+    arr = _as_float_array(mask)
+    if apod_arcmin is None or apod_arcmin <= 0:
+        return arr
+
+    aporad_deg = float(apod_arcmin) / 60.0
+    apodized = nmt.mask_apodization(arr, aporad_deg, apotype="C1")
+    apodized = np.clip(apodized, 0.0, 1.0)
+    apodized = apodized * (arr > 0)
+    return apodized
+
+
+def build_mask(
+    m: np.ndarray,
+    threshold_sigma: float = 10.0,
+    apod_arcmin: float | None = None,
+) -> np.ndarray:
+    """Construct a float mask with thresholding and optional apodization."""
+
+    mask = threshold_mask(m, threshold_sigma=threshold_sigma)
+    mask = apodize_mask(mask, apod_arcmin=apod_arcmin)
+    return mask.astype(float)
+
+
+def effective_f_sky(mask: np.ndarray) -> float:
+    """Compute the sky fraction covered by the (possibly apodized) mask."""
+
+    arr = _as_float_array(mask)
+    return float(np.mean(arr))
+
+
+__all__ = [
+    "apodize_mask",
+    "build_mask",
+    "effective_f_sky",
+    "threshold_mask",
+]

--- a/tests/test_masking_and_binning.py
+++ b/tests/test_masking_and_binning.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy", reason="mask tests require numpy")
+pytest.importorskip("healpy", reason="mask tests require healpy")
+pytest.importorskip("pymaster", reason="mask tests require pymaster")
+
+import healpy as hp
+import numpy as np
+from commutator_common import nm_bins_from_config
+
+from comet.config import load_prereg
+from comet.masking import build_mask, effective_f_sky
+
+
+def test_build_mask_f_sky_within_expected_range():
+    nside = 32
+    npix = hp.nside2npix(nside)
+    theta, _ = hp.pix2ang(nside, np.arange(npix))
+    m = np.cos(theta)
+
+    mask = build_mask(m, threshold_sigma=1.0, apod_arcmin=30.0)
+    f_sky = effective_f_sky(mask)
+
+    assert 0.5 < f_sky < 0.9
+    assert np.all(mask >= 0.0)
+    assert np.all(mask <= 1.0)
+
+
+def test_bins_follow_prereg_configuration():
+    prereg = load_prereg(Path("config/prereg.yaml"))
+    bins_cfg = prereg["ells"]["bins"]
+    nside = 256
+    bins = nm_bins_from_config(nside=nside, bins_cfg=bins_cfg)
+
+    expected_bins = math.ceil((bins_cfg["lmax"] - bins_cfg["lmin"] + 1) / bins_cfg["nlb"])
+    assert bins.get_n_bands() == expected_bins


### PR DESCRIPTION
## Summary
- add a dedicated masking utility that thresholds maps and applies configurable C1 apodization
- wire preregistration-driven binning and mask options into the commutator scripts and provide a mask-building CLI
- cover the new mask and binning behaviour with regression tests and mark phase 2 as complete in the roadmap and project issues

## Testing
- `ruff check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e5d0d16ea0832fb90fb4657917a793